### PR TITLE
add area information to the user before clicking run button

### DIFF
--- a/templates/geosafe/analysis/dynamic_scripts/create/main.html
+++ b/templates/geosafe/analysis/dynamic_scripts/create/main.html
@@ -249,7 +249,7 @@
                         } else {
                             allow_message = 'You can\'t run analysis. Please reduce extent';
                         }
-                        run_message = both_selected + 'Cover an area of ' + formatted_area + ' m2. ' + allow_message;
+                        run_message = both_selected + 'The selected analysis extent is ' + formatted_area + ' m2. ' + allow_message;
                         $run_analysis_popover.popover({title: "Run Analysis", content: run_message});
                         $run_analysis_popover.popover('show');
                     } else {

--- a/templates/geosafe/analysis/dynamic_scripts/create/main.html
+++ b/templates/geosafe/analysis/dynamic_scripts/create/main.html
@@ -224,7 +224,39 @@
 
         {# show run button popover if hazard and exposure were selected #}
         {% if not analysis %}
-            $run_analysis_popover.popover('show');
+                var analysis_url = '{% url 'geosafe:calculate-area' %}';
+                /*var post_data = {
+                    'hazard_id': {{ analysis.hazard_layer_id }},
+                    'exposure_id': {{ analysis.exposure_layer_id }},
+                    'view_extent': '{{ analysis.user_extent }}'
+                };*/
+                var post_data = {
+                'hazard_id': hazard_layer_cbo.find('option:selected').val(),
+                'exposure_id': exposure_layer_cbo.find('option:selected').val(),
+                'view_extent': map.getBounds().toBBoxString()
+            };
+            var both_selected = 'Hazard and exposure are selected. ';
+            var run_message = '';
+            var allow_message = '';
+
+                $.post(analysis_url, post_data, function (data) {
+                    if (data) {
+                        area = data['area'] / 1000000;
+                        formatted_area = numeral(area).format('0,0');
+
+                        if (data['is_valid']) {
+                            allow_message = 'You can now run analysis.';
+                        } else {
+                            allow_message = 'You can\'t run analysis. Please reduce extent';
+                        }
+                        run_message = both_selected + 'Cover an area of ' + formatted_area + ' m2. ' + allow_message;
+                        $run_analysis_popover.popover({title: "Run Analysis", content: run_message});
+                        $run_analysis_popover.popover('show');
+                    } else {
+                        $run_analysis_popover.popover({title: "Run Analysis", content: "If hazard and exposure were selected, you can run analysis"});
+                        $run_analysis_popover.popover('show');
+                    }
+                });
         {% endif %}
 
     }

--- a/templates/geosafe/analysis/options_panel.html
+++ b/templates/geosafe/analysis/options_panel.html
@@ -80,9 +80,7 @@
                 {{ form|as_bootstrap }}
             </div>
             <button id="run-analysis-submit-button" type="submit" class="btn btn-primary" disabled
-                data-toggle="popover" data-trigger="manual" title="Run Analysis"
-                data-content="If hazard and exposure were selected, you can run analysis."
-                >
+                data-toggle="popover" data-trigger="manual">
                 Run
             </button>
         </form>


### PR DESCRIPTION
fix #226

two alternatives were considered:
- allow user to zoom in and out when run dialog shows up -> the dialog would obstruct user's view. i think it's not an ideal solution.
- add tooltip on `Run` button -> inform the user that whether his extent can or can't run. the tooltip can potentially show up before the run button being enabled (at least on my machine) which give way to the user redefining his extent again.

below is the illustration:
![improverun](https://user-images.githubusercontent.com/4602383/30923216-7067f4a8-a3d5-11e7-919d-23e9861da448.gif)



