### PR TITLE
add user and group filter

### DIFF
--- a/views/analysis.py
+++ b/views/analysis.py
@@ -6,7 +6,8 @@ from zipfile import ZipFile
 
 import re
 from django.utils.translation import ugettext as _
-from django.contrib.auth.decorators import login_required, user_passes_test
+from django.contrib.auth.decorators import login_required, \
+    user_passes_test, permission_required
 from django.contrib.gis.geos.geometry import GEOSGeometry
 from django.core.urlresolvers import reverse
 from django.db.models.expressions import F
@@ -18,6 +19,7 @@ from django.views.generic import (
     ListView, CreateView, DetailView)
 from geonode.utils import bbox_to_wkt
 from guardian.shortcuts import get_objects_for_user
+from functools import wraps
 
 from geonode.layers.models import Layer
 from geosafe.app_settings import settings
@@ -38,6 +40,10 @@ LOGGER = logging.getLogger("geosafe")
 
 
 logger = logging.getLogger("geonode.geosafe.analysis")
+# for a complete list of permissions, refer to base.models.ResourceBase.Meta.permissions
+_CERTAIN_PERMS = ['base.view_resourcebase',
+                  'base.change_resourcebase_metadata',
+                  'base.download_resourcebase']
 
 
 def retrieve_layers(
@@ -114,6 +120,42 @@ def retrieve_layers(
     # Filter by permissions
     metadatas = metadatas.filter(layer__id__in=authorized_objects)
     return [m.layer for m in metadatas], is_filtered
+
+
+def decorator_sections(f):
+    """Decorator for AnalysisCreateView class
+    """
+    def _decorator(self, **kwargs):
+
+        authorized_objects = get_objects_for_user(
+            self.request.user, _CERTAIN_PERMS, accept_global_perms=True).values('id')
+        sections = AnalysisCreateView.options_panel_dict(
+            authorized_objects=authorized_objects)
+        kwargs['sections'] = sections
+
+        response = f(self, **kwargs)
+        return response
+
+    return wraps(f)(_decorator)
+
+
+def decorator_sections_panel(f):
+    """Decorator for layer_panel view
+    """
+    def _decorator(request, bbox=None, **kwargs):
+        authorized_objects = get_objects_for_user(
+            request.user, _CERTAIN_PERMS).values('id')
+        sections = AnalysisCreateView.options_panel_dict(
+            authorized_objects=authorized_objects,
+            bbox=bbox)
+
+        kwargs['sections'] = sections
+        kwargs['authorized_objects'] = authorized_objects
+
+        response = f(request, bbox, **kwargs)
+        return response
+
+    return wraps(f)(_decorator)
 
 
 class AnalysisCreateView(CreateView):
@@ -211,11 +253,13 @@ class AnalysisCreateView(CreateView):
         })
         return sections
 
+    @decorator_sections
     def get_context_data(self, **kwargs):
-        authorized_objects = get_objects_for_user(
-            self.request.user, 'base.view_resourcebase').values('id')
-        sections = self.options_panel_dict(
-            authorized_objects=authorized_objects)
+        if kwargs['sections']:
+            sections = kwargs['sections']
+        else:
+            sections = None
+
         try:
             analysis = Analysis.objects.get(id=self.kwargs.get('pk'))
         except:
@@ -272,6 +316,7 @@ class AnalysisListView(ListView):
     context_object_name = 'analysis_list'
     queryset = Analysis.objects.all().order_by("-impact_layer__date")
 
+    @decorator_sections
     def get_context_data(self, **kwargs):
         context = super(AnalysisListView, self).get_context_data(**kwargs)
         context.update({'user': self.request.user})
@@ -283,11 +328,12 @@ class AnalysisDetailView(DetailView):
     template_name = 'geosafe/analysis/detail.html'
     context_object_name = 'analysis'
 
+    @decorator_sections
     def get_context_data(self, **kwargs):
         context = super(AnalysisDetailView, self).get_context_data(**kwargs)
         return context
 
-
+@permission_required(_CERTAIN_PERMS)
 def impact_function_filter(request):
     """Ajax Request for filtered available IF
     """
@@ -321,6 +367,7 @@ def impact_function_filter(request):
         return HttpResponseServerError()
 
 
+@permission_required(_CERTAIN_PERMS)
 def layer_tiles(request):
     """Ajax request to get layer's url to show in the map.
     """
@@ -434,16 +481,15 @@ def layer_list(request, layer_purpose, layer_category=None, bbox=None):
         return HttpResponseServerError()
 
 
-def layer_panel(request, bbox=None):
+@decorator_sections_panel
+def layer_panel(request, bbox=None, **kwargs):
     if request.method != 'GET':
         return HttpResponseBadRequest()
 
     try:
-        authorized_objects = get_objects_for_user(
-            request.user, 'base.view_resourcebase').values('id')
-        sections = AnalysisCreateView.options_panel_dict(
-            authorized_objects=authorized_objects,
-            bbox=bbox)
+        # both authorized_objects and sections are obtained from decorator
+        authorized_objects = kwargs['authorized_objects']
+        sections = kwargs['sections']
         form = AnalysisCreationForm(
             user=request.user,
             exposure_layer=retrieve_layers(

--- a/views/analysis.py
+++ b/views/analysis.py
@@ -6,8 +6,7 @@ from zipfile import ZipFile
 
 import re
 from django.utils.translation import ugettext as _
-from django.contrib.auth.decorators import login_required, \
-    user_passes_test, permission_required
+from django.contrib.auth.decorators import login_required, user_passes_test
 from django.contrib.gis.geos.geometry import GEOSGeometry
 from django.core.urlresolvers import reverse
 from django.db.models.expressions import F
@@ -40,9 +39,8 @@ LOGGER = logging.getLogger("geosafe")
 
 
 logger = logging.getLogger("geonode.geosafe.analysis")
-# for a complete list of permissions, refer to base.models.ResourceBase.Meta.permissions
+# refer to base.models.ResourceBase.Meta.permissions
 _CERTAIN_PERMS = ['base.view_resourcebase',
-                  #'base.change_resourcebase_metadata',
                   'base.download_resourcebase']
 
 
@@ -128,7 +126,9 @@ def decorator_sections(f):
     def _decorator(self, **kwargs):
 
         authorized_objects = get_objects_for_user(
-            self.request.user, _CERTAIN_PERMS, accept_global_perms=True).values('id')
+            self.request.user,
+            _CERTAIN_PERMS,
+            accept_global_perms=True).values('id')
         sections = AnalysisCreateView.options_panel_dict(
             authorized_objects=authorized_objects)
         kwargs['sections'] = sections
@@ -333,7 +333,7 @@ class AnalysisDetailView(DetailView):
         context = super(AnalysisDetailView, self).get_context_data(**kwargs)
         return context
 
-#@permission_required(_CERTAIN_PERMS)
+
 def impact_function_filter(request):
     """Ajax Request for filtered available IF
     """
@@ -367,7 +367,6 @@ def impact_function_filter(request):
         return HttpResponseServerError()
 
 
-#@permission_required(_CERTAIN_PERMS)
 def layer_tiles(request):
     """Ajax request to get layer's url to show in the map.
     """

--- a/views/analysis.py
+++ b/views/analysis.py
@@ -42,7 +42,7 @@ LOGGER = logging.getLogger("geosafe")
 logger = logging.getLogger("geonode.geosafe.analysis")
 # for a complete list of permissions, refer to base.models.ResourceBase.Meta.permissions
 _CERTAIN_PERMS = ['base.view_resourcebase',
-                  'base.change_resourcebase_metadata',
+                  #'base.change_resourcebase_metadata',
                   'base.download_resourcebase']
 
 
@@ -333,7 +333,7 @@ class AnalysisDetailView(DetailView):
         context = super(AnalysisDetailView, self).get_context_data(**kwargs)
         return context
 
-@permission_required(_CERTAIN_PERMS)
+#@permission_required(_CERTAIN_PERMS)
 def impact_function_filter(request):
     """Ajax Request for filtered available IF
     """
@@ -367,7 +367,7 @@ def impact_function_filter(request):
         return HttpResponseServerError()
 
 
-@permission_required(_CERTAIN_PERMS)
+#@permission_required(_CERTAIN_PERMS)
 def layer_tiles(request):
     """Ajax request to get layer's url to show in the map.
     """

--- a/views/analysis.py
+++ b/views/analysis.py
@@ -40,8 +40,7 @@ LOGGER = logging.getLogger("geosafe")
 
 logger = logging.getLogger("geonode.geosafe.analysis")
 # refer to base.models.ResourceBase.Meta.permissions
-_CERTAIN_PERMS = ['base.view_resourcebase',
-                  'base.download_resourcebase']
+_VIEW_PERMS = 'base.view_resourcebase'
 
 
 def retrieve_layers(
@@ -127,7 +126,7 @@ def decorator_sections(f):
 
         authorized_objects = get_objects_for_user(
             self.request.user,
-            _CERTAIN_PERMS,
+            _VIEW_PERMS,
             accept_global_perms=True).values('id')
         sections = AnalysisCreateView.options_panel_dict(
             authorized_objects=authorized_objects)
@@ -144,7 +143,7 @@ def decorator_sections_panel(f):
     """
     def _decorator(request, bbox=None, **kwargs):
         authorized_objects = get_objects_for_user(
-            request.user, _CERTAIN_PERMS).values('id')
+            request.user, _VIEW_PERMS).values('id')
         sections = AnalysisCreateView.options_panel_dict(
             authorized_objects=authorized_objects,
             bbox=bbox)


### PR DESCRIPTION
fix #242

Use case:
two users with the following details:
- username: `simple`
group member: `anonymous` (have no permissions)
- username: `freshman`
group member: `anonymous` and `test` (have all permissions)

# Create page
## `simple` - the user can only see his uploaded layers:
![geosafe 242](https://user-images.githubusercontent.com/4602383/31264211-b1a21544-aa91-11e7-89e1-c70ebacf756a.gif)

## `freshman` - the user can see all the uploaded layers:
![geosafe 242-part2](https://user-images.githubusercontent.com/4602383/31264249-f2180020-aa91-11e7-8f2a-e8521851ae2d.gif)

# Analysis List page

Both `simple` and `freshman` can see the analysis list result:
![geosafe 242-part3](https://user-images.githubusercontent.com/4602383/31264306-4e962a02-aa92-11e7-913c-d4fd217b0317.gif) 

However, `simple` unable to see the analysis result. Meanwhile, `freshman` can see his result:
![geosafe 242-part4](https://user-images.githubusercontent.com/4602383/31264329-7ae6fc3a-aa92-11e7-90e4-fce7f2ec5bfc.gif)
