### PR TITLE
generate report after analysis succeded

### DIFF
--- a/tasks/analysis.py
+++ b/tasks/analysis.py
@@ -300,12 +300,12 @@ def process_impact_result(self, impact_result, analysis_id):
         # generate report when analysis has ran successfully
         async = generate_report.delay(impact_url)
         with allow_join_result():
-            report_metadata = (
-                async.get().get('output', {}).get('pdf_product_tag', {}))
+            report_metadata = async.get().get('output', {})
 
-        for report_key, report_url in report_metadata.iteritems():
-            report_url = download_file(report_url, direct_access=True)
-            report_metadata[report_key] = report_url
+        for product_key, products in report_metadata.iteritems():
+            for report_key, report_url in products.iteritems():
+                report_url = download_file(report_url, direct_access=True)
+                report_metadata[product_key][report_key] = report_url
 
         # decide if we are using direct access or not
         impact_url = get_impact_path(impact_url)
@@ -431,21 +431,24 @@ def process_impact_report(analysis, report_metadata):
     try:
         # extract report (map and table report)
         map_reports = [
-            'inasafe-map-report-portrait',
-            'inasafe-map-report-landscape',
+            'inasafe-map-report-portrait',  # pdf product
+            'inasafe-map-report-landscape',  # pdf product
         ]
         table_reports = [
-            'impact-report-pdf'
+            'impact-report',  # html product
+            'impact-report-pdf'  # pdf product
         ]
 
         # upload using document upload form post request
         #TODO: find out how to upload document using post request
 
         # assign report to analysis model
-        if os.path.exists(report_metadata[map_reports[0]]):
-            analysis.assign_report_map(report_metadata[map_reports[0]])
-        if os.path.exists(report_metadata[table_reports[0]]):
-            analysis.assign_report_table(report_metadata[table_reports[0]])
+        if os.path.exists(report_metadata['pdf_product_tag'][map_reports[0]]):
+            analysis.assign_report_map(
+                report_metadata['pdf_product_tag'][map_reports[0]])
+        if os.path.exists(report_metadata['pdf_product_tag'][table_reports[1]]):
+            analysis.assign_report_table(
+                report_metadata['pdf_product_tag'][table_reports[1]])
         analysis.save()
 
         # reference to impact layer

--- a/tasks/analysis.py
+++ b/tasks/analysis.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from zipfile import ZipFile
 
 from celery import chain
+from celery.result import allow_join_result
 from django.core.urlresolvers import reverse
 from django.db.models.query_utils import Q
 from lxml import etree
@@ -26,7 +27,7 @@ from geosafe.helpers.utils import (
     get_impact_path)
 from geosafe.models import Analysis, Metadata
 from geosafe.tasks.headless.analysis import (
-    get_keywords, run_analysis, RESULT_SUCCESS)
+    get_keywords, generate_report, run_analysis, RESULT_SUCCESS)
 
 __author__ = 'lucernae'
 
@@ -296,6 +297,16 @@ def process_impact_result(self, impact_result, analysis_id):
     if impact_result['status'] == RESULT_SUCCESS:
         impact_url = impact_result['output']['impact_analysis']
 
+        # generate report when analysis has ran successfully
+        async = generate_report.delay(impact_url)
+        with allow_join_result():
+            report_metadata = (
+                async.get().get('output', {}).get('pdf_product_tag', {}))
+
+        for report_key, report_url in report_metadata.iteritems():
+            report_url = download_file(report_url, direct_access=True)
+            report_metadata[report_key] = report_url
+
         # decide if we are using direct access or not
         impact_url = get_impact_path(impact_url)
 
@@ -329,6 +340,7 @@ def process_impact_result(self, impact_result, analysis_id):
             filename = os.path.basename(impact_path)
             basename, ext = os.path.splitext(filename)
             success = process_impact_layer(analysis, basename, dir_name, filename)
+            report_success = process_impact_report(analysis, report_metadata)
 
             # cleanup
             for name in os.listdir(dir_name):
@@ -371,8 +383,7 @@ def process_impact_layer(analysis, basename, dir_name, name):
     :return: True if success
     """
     saved_layer = file_upload(
-        os.path.join(dir_name, name),
-        overwrite=True)
+        os.path.join(dir_name, name))
     saved_layer.set_default_permissions()
     if analysis.user_title:
         layer_name = analysis.user_title
@@ -402,4 +413,47 @@ def process_impact_layer(analysis, basename, dir_name, name):
     if current_impact:
         current_impact.delete()
     success = True
+    return success
+
+
+def process_impact_report(analysis, report_metadata):
+    """Internal method to process impact report.
+
+    :param analysis: Analysis object
+    :type analysis: Analysis
+
+    :param report_metadata: Impact report metadata
+    :type report_metadata: dict
+
+    :return: True if success
+    """
+    success = False
+    try:
+        # extract report (map and table report)
+        map_reports = [
+            'inasafe-map-report-portrait',
+            'inasafe-map-report-landscape',
+        ]
+        table_reports = [
+            'impact-report-pdf'
+        ]
+
+        # upload using document upload form post request
+        #TODO: find out how to upload document using post request
+
+        # assign report to analysis model
+        if os.path.exists(report_metadata[map_reports[0]]):
+            analysis.assign_report_map(report_metadata[map_reports[0]])
+        if os.path.exists(report_metadata[table_reports[0]]):
+            analysis.assign_report_table(report_metadata[table_reports[0]])
+        analysis.save()
+
+        # reference to impact layer
+        # TODO: find out how to upload document using post request first
+
+        success = True
+    except Exception as e:
+        LOGGER.debug(e)
+        pass
+
     return success

--- a/templates/geosafe/analysis/detail.html
+++ b/templates/geosafe/analysis/detail.html
@@ -55,6 +55,23 @@
                             </div>
                         {% endif %}
                     </p>
+
+                    <p>Impact Map Report:
+                        {% if analysis.report_map %}
+                            <a class="download-link" href="{% url 'geosafe:download-report' analysis_id=analysis.id data_type='map' %}" target="_blank">Map Report</a>
+                        {% else %}
+                            There is no map report generated for this Impact Layer
+                        {% endif %}
+                    </p>
+
+                    <p>Impact Table Report:
+                        {% if analysis.report_table %}
+                            <a class="download-link" href="{% url 'geosafe:download-report' analysis_id=analysis.id data_type='table' %}" target="_blank">Table Report</a>
+                        {% else %}
+                            There is no table report generated for this Impact Layer
+                        {% endif %}
+                    </p>
+
                     {% if analysis.get_task_result %}
                         {% if analysis.get_task_result.successful or analysis.get_task_result.failed %}
                             <p>

--- a/templates/geosafe/analysis/dynamic_scripts/create/main.html
+++ b/templates/geosafe/analysis/dynamic_scripts/create/main.html
@@ -183,6 +183,29 @@
     }
 
     /**
+     * Open the Impact Report PDF product.
+     *
+     * A summary about the analysis.
+     */
+    function open_impact_report() {
+        if (last_impact_id == undefined) {
+            show_info_text('Show Analysis Summary', 'Please select desired impact layer first, before viewing analysis summary.')
+            return;
+        }
+        var selected_impact_id = last_impact_id;
+        var check_impact_url = '{% url 'geosafe:check-impact' impact_id=-1 %}';
+        check_impact_url = check_impact_url.replace("-1", selected_impact_id);
+
+        $.get(check_impact_url, function (data) {
+            if (data && data.analysis_id) {
+                var url = '{% url 'geosafe:download-report' analysis_id=-1 data_type='table' %}';
+                url = url.replace("-1", data.analysis_id);
+                window.open(url);
+            }
+        });
+    }
+
+    /**
      * Show url inside frame
      *
      * Useful to display PDF report

--- a/templates/geosafe/analysis/list.html
+++ b/templates/geosafe/analysis/list.html
@@ -148,19 +148,19 @@
                             {% endif %}
                         </td>
                         <td>
+                            <div>
+                                <a class="download-link" href="{% url 'geosafe:analysis-create' pk=analysis.id %}">Analysis Page</a>
+                            </div>
                             {% if analysis.report_map %}
                                 <div>
-                                    <a class="download-link" href="{% url 'geosafe:download-report' analysis_id=analysis.id data_type='map' %}">Map Report</a>
+                                    <a class="download-link" href="{% url 'geosafe:download-report' analysis_id=analysis.id data_type='map' %}" target="_blank">Map Report</a>
                                 </div>
                             {% endif %}
                             {% if analysis.report_table %}
                                 <div>
-                                    <a class="download-link" href="{% url 'geosafe:download-report' analysis_id=analysis.id data_type='table' %}">Table Report</a>
+                                    <a class="download-link" href="{% url 'geosafe:download-report' analysis_id=analysis.id data_type='table' %}" target="_blank">Table Report</a>
                                 </div>
                             {% endif %}
-                            <div>
-                                <a class="download-link" href="{% url 'geosafe:analysis-create' pk=analysis.id %}">Analysis Page</a>
-                            </div>
                         </td>
                         {% if user.username %}
                         <td>

--- a/templates/geosafe/analysis/options_panel.html
+++ b/templates/geosafe/analysis/options_panel.html
@@ -98,7 +98,7 @@
         </div>
         {% endfor %}
         <div id="summary-option" class="option">
-            <a href="javascript:show_analysis_summary()"
+            <a href="javascript:open_impact_report()"  {# This is temporary. We need to update show_analysis_summary() function. #}
                 title="Show Analysis Summary">
                 <img src="{% static "geosafe/img/show-summary.svg" %}" alt="Show Analysis Summary" class="svg"/>
             </a>

--- a/urls.py
+++ b/urls.py
@@ -12,7 +12,7 @@ from geosafe.views.analysis import (
     layer_archive,
     layer_list, rerun_analysis,
     analysis_json, toggle_analysis_saved, download_report, layer_panel,
-    analysis_summary, cancel_analysis, validate_analysis_extent)
+    analysis_summary, cancel_analysis, validate_analysis_extent, impact_json)
 
 urlpatterns = patterns(
     '',
@@ -89,6 +89,12 @@ urlpatterns = patterns(
         name='check-analysis'
     ),
     url(
+        r'^analysis/check-impact/'
+        r'(?P<impact_id>[-\d]+)',
+        impact_json,
+        name='check-impact'
+    ),
+    url(
         r'^analysis/toggle-saved/'
         r'(?P<analysis_id>[-\d]+)',
         toggle_analysis_saved,
@@ -96,7 +102,7 @@ urlpatterns = patterns(
     ),
     url(
         r'^analysis/report/'
-        r'(?P<analysis_id>\d+)/'
+        r'(?P<analysis_id>[-\d]+)/'
         r'(?P<data_type>(map|table|reports|all))',
         download_report,
         name='download-report'

--- a/views/analysis.py
+++ b/views/analysis.py
@@ -658,6 +658,29 @@ def analysis_json(request, analysis_id):
         return HttpResponseServerError()
 
 
+def impact_json(request, impact_id):
+    """Return the detail of an impact layer
+
+    :param request:
+    :param impact_layer_id:
+    :return:
+    """
+    if request.method != 'GET':
+        return HttpResponseBadRequest()
+
+    try:
+        analysis = Analysis.objects.get(impact_layer_id=impact_id)
+        retval = {
+            'analysis_id': analysis.id,
+            'impact_id': analysis.impact_layer_id
+        }
+        return HttpResponse(
+            json.dumps(retval), content_type="application/json")
+    except Exception as e:
+        LOGGER.exception(e)
+        return HttpResponseServerError()
+
+
 def toggle_analysis_saved(request, analysis_id):
     """Toggle the state of keep of analysis
 


### PR DESCRIPTION
part fix #335 fix #341 
for now, I show the report by opening the pdf in new tab. We will do that until I can manage to update the geosafe impact card report.
![report-geosafe](https://user-images.githubusercontent.com/11134669/44715058-0c911b80-aae1-11e8-8abc-0ab7f6ff7e2c.gif)


* I found that waiting for the result of `generate_report` task takes more time. 
* In this PR, I'm still using old approach to store impact report which is on Analysis object's attribute.
* Upcoming commit or PR will move the impact report to Geonode's document object and render the html report.